### PR TITLE
Add registration-district data file

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,14 @@
+
+target: data/registration-district/registration-district.tsv
+
+data/registration-district/registration-district.tsv: ../local-authority-data/maps/registration-district.tsv
+	@mkdir -p data/registration-district
+	csvcut -tc registration-district,registration-district-name,local-authority ../local-authority-data/maps/registration-district.tsv \
+	| sed 's/registration-district-name/name/' \
+	| sed 's/name,local-authority/name,local-authority,start-date,end-date/' \
+	| sed -E 's/([A-Z][A-Z][A-Z])$$/\1,,/g' \
+	| csvformat -T \
+	> $@
+
+clean:
+	rm -f data/registration-district/registration-district.tsv

--- a/data/registration-district/registration-district.tsv
+++ b/data/registration-district/registration-district.tsv
@@ -1,0 +1,176 @@
+registration-district	name	local-authority	start-date	end-date
+218	Barking and Dagenham	local-authority-eng:BDG		
+219	Barnet	local-authority-eng:BNE		
+41	Barnsley	local-authority-eng:BNS		
+300	Bath and North East Somerset	local-authority-eng:BAS		
+316	Bedford	local-authority-eng:BDF		
+220	Bexley	local-authority-eng:BEX		
+61	Birmingham	local-authority-eng:BIR		
+580	Blackburn With Darwen	local-authority-eng:BBD		
+581	Blackpool	local-authority-eng:BPL		
+833	Blaenau Gwent	local-authority-wls:BGW		
+2	Bolton	local-authority-eng:BOL		
+427	Bournemouth	local-authority-eng:BMH		
+318	Bracknell Forest	local-authority-eng:BRC		
+83	Bradford and Keighley	local-authority-eng:BRD		
+221	Brent	local-authority-eng:BEN		
+861	Bridgend	local-authority-wls:BGE		
+452	Brighton and Hove	local-authority-eng:BNH		
+301	Bristol	local-authority-eng:BST		
+222	Bromley	local-authority-eng:BRY		
+328	Buckinghamshire	local-authority-eng:BKM		
+3	Bury	local-authority-eng:BUR		
+863	Caerphilly	local-authority-wls:CAY		
+86	Calderdale	local-authority-eng:CLD		
+339	Cambridgeshire	local-authority-eng:CAM		
+250	Camden	local-authority-eng:CMD		
+890	Cardiff	local-authority-wls:CRF		
+822	Carmarthenshire	local-authority-wls:CMN		
+317	Central Bedfordshire	local-authority-eng:CBF		
+823	Ceredigion	local-authority-wls:CGN		
+342	Cheshire East	local-authority-eng:CHE		
+345	Cheshire West and Chester	local-authority-eng:CHW		
+846	Conwy	local-authority-wls:CWY		
+371	Cornwall	local-authority-eng:CON		
+442	County of Durham	local-authority-eng:DUR		
+63	Coventry	local-authority-eng:COV		
+225	Croydon	local-authority-eng:CRY		
+387	Cumbria	local-authority-eng:CMA		
+436	Darlington	local-authority-eng:DAL		
+811	Denbighshire North	local-authority-wls:DEN		
+805	Denbighshire South	local-authority-wls:DEN		
+394	Derby	local-authority-eng:DER		
+398	Derbyshire	local-authority-eng:DBY		
+423	Devon	local-authority-eng:DEV		
+42	Doncaster	local-authority-eng:DNC		
+429	Dorset	local-authority-eng:DOR		
+65	Dudley	local-authority-eng:DUD		
+226	Ealing	local-authority-eng:EAL		
+541	East Riding of Yorkshire	local-authority-eng:ERY		
+462	East Sussex	local-authority-eng:ESX		
+227	Enfield	local-authority-eng:ENF		
+463	Essex	local-authority-eng:ESS		
+804	Flintshire	local-authority-wls:FLN		
+51	Gateshead	local-authority-eng:GAT		
+488	Gloucestershire	local-authority-eng:GLS		
+229	Greenwich	local-authority-eng:GRE		
+855	Gwynedd	local-authority-wls:GWN		
+230	Hackney	local-authority-eng:HCK		
+343	Halton	local-authority-eng:HAL		
+260	Hammersmith and Fulham	local-authority-eng:HMF		
+504	Hampshire	local-authority-eng:HAM		
+233	Haringey	local-authority-eng:HRY		
+232	Harrow	local-authority-eng:HRW		
+351	Hartlepool	local-authority-eng:HPL		
+234	Havering	local-authority-eng:HAV		
+511	Herefordshire	local-authority-eng:HEF		
+538	Hertfordshire	local-authority-eng:HRT		
+236	Hillingdon	local-authority-eng:HIL		
+237	Hounslow	local-authority-eng:HNS		
+550	Hull	local-authority-eng:KHL		
+556	Isle of Wight	local-authority-eng:IOW		
+360	Isles of Scilly	local-authority-eng:IOS		
+238	Islington	local-authority-eng:ISL		
+239	Kensington and Chelsea	local-authority-eng:KEC		
+564	Kent	local-authority-eng:KEN		
+240	Kingston Upon Thames	local-authority-eng:KTT		
+90	Kirklees	local-authority-eng:KIR		
+23	Knowsley	local-authority-eng:KWL		
+241	Lambeth	local-authority-eng:LBH		
+591	Lancashire	local-authority-eng:LAN		
+92	Leeds	local-authority-eng:LDS		
+600	Leicester	local-authority-eng:LCE		
+605	Leicestershire	local-authority-eng:LEC		
+242	Lewisham	local-authority-eng:LEW		
+609	Lincolnshire	local-authority-eng:LIN		
+25	Liverpool	local-authority-eng:LIV		
+243	London City	local-authority-eng:LND		
+315	Luton	local-authority-eng:LUT		
+6	Manchester	local-authority-eng:MAN		
+561	Medway	local-authority-eng:MDW		
+860	Merthyr Tydfil	local-authority-wls:MTY		
+244	Merton	local-authority-eng:MRT		
+348	Middlesbrough	local-authority-eng:MDB		
+326	Milton Keynes	local-authority-eng:MIK		
+839	Monmouthshire	local-authority-wls:MON		
+896	Neath Port Talbot	local-authority-wls:NTL		
+53	Newcastle Upon Tyne	local-authority-eng:NET		
+257	Newham	local-authority-eng:NWM		
+836	Newport	local-authority-wls:NWP		
+642	Norfolk	local-authority-eng:NFK		
+548	North East Lincolnshire	local-authority-eng:NEL		
+554	North Lincolnshire	local-authority-eng:NLN		
+307	North Somerset	local-authority-eng:NSM		
+54	North Tyneside	local-authority-eng:NTY		
+650	North Yorkshire	local-authority-eng:NYK		
+674	Northamptonshire	local-authority-eng:NTH		
+681	Northumberland	local-authority-eng:NBL		
+689	Nottingham	local-authority-eng:NGM		
+692	Nottinghamshire	local-authority-eng:NTT		
+7	Oldham	local-authority-eng:OLD		
+695	Oxfordshire	local-authority-eng:OXF		
+819	Pembrokeshire	local-authority-wls:PEM		
+335	Peterborough	local-authority-eng:PTE		
+416	Plymouth	local-authority-eng:PLY		
+431	Poole	local-authority-eng:POL		
+497	Portsmouth	local-authority-eng:POR		
+882	Powys	local-authority-wls:POW		
+320	Reading	local-authority-eng:RDG		
+247	Redbridge	local-authority-eng:RDB		
+349	Redcar and Cleveland	local-authority-eng:RCC		
+864	Rhondda Cynon Taf	local-authority-wls:RCT		
+248	Richmond Upon Thames	local-authority-eng:RIC		
+9	Rochdale	local-authority-eng:RCH		
+45	Rotherham	local-authority-eng:ROT		
+604	Rutland	local-authority-eng:RUT		
+11	Salford	local-authority-eng:SLF		
+70	Sandwell	local-authority-eng:SAW		
+35	Sefton	local-authority-eng:SFT		
+48	Sheffield	local-authority-eng:SHF		
+717	Shropshire	local-authority-eng:SHR		
+321	Slough	local-authority-eng:SLG		
+73	Solihull	local-authority-eng:SOL		
+722	Somerset	local-authority-eng:SOM		
+304	South Gloucestershire	local-authority-eng:SGC		
+57	South Tyneside	local-authority-eng:STY		
+500	Southampton	local-authority-eng:STH		
+475	Southend-on-Sea	local-authority-eng:SOS		
+251	Southwark	local-authority-eng:SWK		
+30	St Helens	local-authority-eng:SHN		
+738	Staffordshire	local-authority-eng:STS		
+13	Stockport	local-authority-eng:SKP		
+350	Stockton-on-Tees	local-authority-eng:STT		
+737	Stoke-on-Trent	local-authority-eng:STE		
+748	Suffolk	local-authority-eng:SFK		
+58	Sunderland	local-authority-eng:SND		
+759	Surrey	local-authority-eng:SRY		
+254	Sutton	local-authority-eng:STN		
+897	Swansea	local-authority-wls:SWA		
+796	Swindon	local-authority-eng:SWD		
+14	Tameside	local-authority-eng:TAM		
+716	Telford and Wrekin	local-authority-eng:TFW		
+477	Thurrock	local-authority-eng:THR		
+422	Torbay	local-authority-eng:TOB		
+837	Torfaen	local-authority-wls:TOF		
+246	Tower Hamlets	local-authority-eng:TWH		
+15	Trafford	local-authority-eng:TRF		
+891	Vale of Glamorgan	local-authority-wls:VGL		
+97	Wakefield	local-authority-eng:WKF		
+75	Walsall	local-authority-eng:WLL		
+255	Waltham Forest	local-authority-eng:WFT		
+256	Wandsworth	local-authority-eng:WND		
+346	Warrington	local-authority-eng:WRT		
+776	Warwickshire	local-authority-eng:WAR		
+319	West Berkshire	local-authority-eng:WBK		
+785	West Sussex	local-authority-eng:WSX		
+258	Westminster	local-authority-eng:WSM		
+18	Wigan and Leigh	local-authority-eng:WGN		
+799	Wiltshire	local-authority-eng:WIL		
+322	Windsor and Maidenhead	local-authority-eng:WNM		
+37	Wirral	local-authority-eng:WRL		
+323	Wokingham	local-authority-eng:WOK		
+77	Wolverhampton	local-authority-eng:WLV		
+527	Worcestershire	local-authority-eng:WOR		
+813	Wrexham	local-authority-wls:WRX		
+857	Ynys Mon	local-authority-wls:AGY		
+661	York	local-authority-eng:YOR		


### PR DESCRIPTION
- Add registration-data file derived from registration-district map file in the local-authority-data directory.
- The data originates from a General Register Office internal list of register officers.